### PR TITLE
Fix incorrect component in cocina page

### DIFF
--- a/src/app/cocina/page.tsx
+++ b/src/app/cocina/page.tsx
@@ -1,12 +1,12 @@
 import ProtectedRoute from '@/components/ProtectedRoute'
 
-export default function MeseroPage() {
+export default function CocinaPage() {
   return (
-    <ProtectedRoute allowRoles={['cocina']}>
-      <main className="p-6">
-        <h1 className="text-2xl font-bold">Panel de Mesero 🧾</h1>
-        {/* Aquí irán los botones para tomar órdenes */}
-      </main>
-    </ProtectedRoute>
+      <ProtectedRoute allowRoles={['cocina']}>
+        <main className="p-6">
+          <h1 className="text-2xl font-bold">Panel de Cocina 🍳</h1>
+          {/* Aquí irán los botones para gestionar la cocina */}
+        </main>
+      </ProtectedRoute>
   )
 }


### PR DESCRIPTION
## Summary
- fix the component name and heading for `cocina` page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452d3588488321b8247ada06cc6d53