### PR TITLE
Add waiter panel and order area views

### DIFF
--- a/src/app/barra/page.tsx
+++ b/src/app/barra/page.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import ProtectedRoute from "@/components/ProtectedRoute"
+import { supabase } from "../../../supabase/client"
+
+interface Orden {
+  id: number
+  mesa: string
+  productos: { nombre: string; precio: number }[]
+  estado: string
+}
+
+export default function BarraPage() {
+  const [ordenes, setOrdenes] = useState<Orden[]>([])
+
+  const obtenerOrdenes = async () => {
+    const { data } = await supabase
+      .from("ordenes")
+      .select("*")
+      .eq("area", "barra")
+      .order("created_at", { ascending: false })
+    if (data) setOrdenes(data as Orden[])
+  }
+
+  useEffect(() => {
+    obtenerOrdenes()
+  }, [])
+
+  const marcarListo = async (id: number) => {
+    const { error } = await supabase
+      .from("ordenes")
+      .update({ estado: "listo" })
+      .eq("id", id)
+    if (!error) {
+      setOrdenes((o) => o.map((ord) => (ord.id === id ? { ...ord, estado: "listo" } : ord)))
+    }
+  }
+
+  return (
+    <ProtectedRoute allowRoles={["barman"]}>
+      <main className="p-6">
+        <h1 className="text-2xl font-bold mb-4">Órdenes de Barra</h1>
+        <div className="space-y-4">
+          {ordenes.map((o) => (
+            <div key={o.id} className="border p-3 rounded">
+              <h2 className="font-semibold">
+                {o.mesa} - {o.estado}
+              </h2>
+              <ul className="list-disc pl-5">
+                {o.productos.map((p, i) => (
+                  <li key={i}>
+                    {p.nombre} - ${p.precio}
+                  </li>
+                ))}
+              </ul>
+              {o.estado === "pendiente" && (
+                <button
+                  onClick={() => marcarListo(o.id)}
+                  className="mt-2 bg-green-600 text-white px-2 py-1 rounded"
+                >
+                  Marcar listo
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </main>
+    </ProtectedRoute>
+  )
+}

--- a/src/app/caja/page.tsx
+++ b/src/app/caja/page.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import ProtectedRoute from "@/components/ProtectedRoute"
+import { supabase } from "../../../supabase/client"
+
+interface Orden {
+  id: number
+  mesa: string
+  productos: { nombre: string; precio: number }[]
+  estado: string
+}
+
+export default function CajaPage() {
+  const [ordenes, setOrdenes] = useState<Orden[]>([])
+
+  const obtenerOrdenes = async () => {
+    const { data } = await supabase.from("ordenes").select("*").order("created_at", { ascending: false })
+    if (data) setOrdenes(data as Orden[])
+  }
+
+  useEffect(() => {
+    obtenerOrdenes()
+  }, [])
+
+  const marcarPagado = async (id: number) => {
+    const { error } = await supabase.from("ordenes").update({ estado: "pagado" }).eq("id", id)
+    if (!error) {
+      setOrdenes((o) => o.map((ord) => (ord.id === id ? { ...ord, estado: "pagado" } : ord)))
+    }
+  }
+
+  const ordenesPorMesa = ordenes.reduce<Record<string, Orden[]>>((acc, ord) => {
+    if (!acc[ord.mesa]) acc[ord.mesa] = []
+    acc[ord.mesa].push(ord)
+    return acc
+  }, {})
+
+  const totalMesa = (lista: Orden[]) =>
+    lista.reduce(
+      (sum, ord) => sum + ord.productos.reduce((s, p) => s + (p.precio || 0), 0),
+      0
+    )
+
+  return (
+    <ProtectedRoute allowRoles={["caja"]}>
+      <main className="p-6">
+        <h1 className="text-2xl font-bold mb-4">Caja</h1>
+        <div className="space-y-6">
+          {Object.entries(ordenesPorMesa).map(([mesa, lista]) => (
+            <div key={mesa} className="border p-3 rounded">
+              <h2 className="font-semibold mb-2">
+                {mesa} - Total ${totalMesa(lista).toFixed(2)}
+              </h2>
+              {lista.map((o) => (
+                <div key={o.id} className="mb-2 border p-2 rounded">
+                  <p>
+                    Orden #{o.id} - {o.estado}
+                  </p>
+                  <ul className="list-disc pl-5">
+                    {o.productos.map((p, i) => (
+                      <li key={i}>
+                        {p.nombre} - ${p.precio}
+                      </li>
+                    ))}
+                  </ul>
+                  {o.estado !== "pagado" && (
+                    <button
+                      onClick={() => marcarPagado(o.id)}
+                      className="mt-1 bg-green-600 text-white px-2 py-1 rounded"
+                    >
+                      Marcar pagado
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </main>
+    </ProtectedRoute>
+  )
+}

--- a/src/app/cocina/page.tsx
+++ b/src/app/cocina/page.tsx
@@ -1,11 +1,70 @@
-import ProtectedRoute from '@/components/ProtectedRoute'
+"use client"
 
-export default function MeseroPage() {
+import { useEffect, useState } from "react"
+import ProtectedRoute from "@/components/ProtectedRoute"
+import { supabase } from "../../../supabase/client"
+
+interface Orden {
+  id: number
+  mesa: string
+  productos: { nombre: string; precio: number }[]
+  estado: string
+}
+
+export default function CocinaPage() {
+  const [ordenes, setOrdenes] = useState<Orden[]>([])
+
+  const obtenerOrdenes = async () => {
+    const { data } = await supabase
+      .from("ordenes")
+      .select("*")
+      .eq("area", "cocina")
+      .order("created_at", { ascending: false })
+    if (data) setOrdenes(data as Orden[])
+  }
+
+  useEffect(() => {
+    obtenerOrdenes()
+  }, [])
+
+  const marcarListo = async (id: number) => {
+    const { error } = await supabase
+      .from("ordenes")
+      .update({ estado: "listo" })
+      .eq("id", id)
+    if (!error) {
+      setOrdenes((o) => o.map((ord) => (ord.id === id ? { ...ord, estado: "listo" } : ord)))
+    }
+  }
+
   return (
-    <ProtectedRoute allowRoles={['cocina']}>
+    <ProtectedRoute allowRoles={["cocina"]}>
       <main className="p-6">
-        <h1 className="text-2xl font-bold">Panel de Mesero 🧾</h1>
-        {/* Aquí irán los botones para tomar órdenes */}
+        <h1 className="text-2xl font-bold mb-4">Órdenes de Cocina</h1>
+        <div className="space-y-4">
+          {ordenes.map((o) => (
+            <div key={o.id} className="border p-3 rounded">
+              <h2 className="font-semibold">
+                {o.mesa} - {o.estado}
+              </h2>
+              <ul className="list-disc pl-5">
+                {o.productos.map((p, i) => (
+                  <li key={i}>
+                    {p.nombre} - ${p.precio}
+                  </li>
+                ))}
+              </ul>
+              {o.estado === "pendiente" && (
+                <button
+                  onClick={() => marcarListo(o.id)}
+                  className="mt-2 bg-green-600 text-white px-2 py-1 rounded"
+                >
+                  Marcar listo
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
       </main>
     </ProtectedRoute>
   )

--- a/src/app/mesero/page.tsx
+++ b/src/app/mesero/page.tsx
@@ -1,11 +1,110 @@
-import ProtectedRoute from '@/components/ProtectedRoute'
+"use client"
+
+import { useState } from "react"
+import ProtectedRoute from "@/components/ProtectedRoute"
+import { supabase } from "../../../supabase/client"
+
+type Producto = {
+  nombre: string
+  tipo: "comida" | "bebida"
+  precio: number
+}
 
 export default function MeseroPage() {
+  const [mesa, setMesa] = useState<string | null>(null)
+  const [tipo, setTipo] = useState<"comida" | "bebida">("comida")
+  const [nombre, setNombre] = useState("")
+  const [precio, setPrecio] = useState("")
+  const [productos, setProductos] = useState<Producto[]>([])
+  const [mensaje, setMensaje] = useState("")
+
+  const usuarioRaw = typeof window !== "undefined" ? localStorage.getItem("usuario") : null
+  const usuario = usuarioRaw ? JSON.parse(usuarioRaw) : null
+
+  const addProducto = () => {
+    if (!nombre) return
+    setProductos([...productos, { nombre, tipo, precio: parseFloat(precio) || 0 }])
+    setNombre("")
+    setPrecio("")
+  }
+
+  const enviarPedido = async () => {
+    if (!mesa || productos.length === 0) {
+      setMensaje("Seleccione mesa y agregue productos")
+      return
+    }
+
+    const grupos: Record<"comida" | "bebida", Producto[]> = { comida: [], bebida: [] }
+    productos.forEach((p) => grupos[p.tipo].push(p))
+
+    for (const [tipoGrupo, items] of Object.entries(grupos) as ["comida" | "bebida", Producto[]][]) {
+      if (items.length === 0) continue
+      const area = tipoGrupo === "comida" ? "cocina" : "barra"
+      const { error } = await supabase.from("ordenes").insert({
+        mesa,
+        productos: items,
+        estado: "pendiente",
+        area,
+        creado_por: usuario?.id,
+      })
+      if (error) {
+        console.error(error)
+        setMensaje("Error al enviar pedido")
+        return
+      }
+    }
+
+    setProductos([])
+    setMesa(null)
+    setMensaje("Pedido enviado")
+  }
+
   return (
-    <ProtectedRoute allowRoles={['mesero']}>
-      <main className="p-6">
+    <ProtectedRoute allowRoles={["mesero"]}>
+      <main className="p-6 space-y-4">
         <h1 className="text-2xl font-bold">Panel de Mesero 🧾</h1>
-        {/* Aquí irán los botones para tomar órdenes */}
+
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 10 }).map((_, i) => {
+            const m = `Mesa ${i + 1}`
+            return (
+              <button
+                key={m}
+                onClick={() => setMesa(m)}
+                className={`px-3 py-2 rounded ${mesa === m ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+              >
+                {m}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-2 items-center">
+            <select value={tipo} onChange={(e) => setTipo(e.target.value as "comida" | "bebida")} className="border p-2 rounded">
+              <option value="comida">Comida</option>
+              <option value="bebida">Bebida</option>
+            </select>
+            <input type="text" placeholder="Producto" value={nombre} onChange={(e) => setNombre(e.target.value)} className="border p-2 rounded" />
+            <input type="number" placeholder="Precio" value={precio} onChange={(e) => setPrecio(e.target.value)} className="border p-2 rounded w-24" />
+            <button onClick={addProducto} className="bg-green-600 text-white px-3 py-2 rounded">
+              Agregar
+            </button>
+          </div>
+
+          <ul className="list-disc pl-5">
+            {productos.map((p, i) => (
+              <li key={i}>
+                {p.nombre} - {p.tipo} - ${p.precio.toFixed(2)}
+              </li>
+            ))}
+          </ul>
+
+          <button onClick={enviarPedido} className="bg-blue-600 text-white px-4 py-2 rounded">
+            Enviar pedido
+          </button>
+          {mensaje && <p>{mensaje}</p>}
+        </div>
       </main>
     </ProtectedRoute>
   )


### PR DESCRIPTION
## Summary
- implement waiter panel to create orders and send them to Supabase
- list orders for kitchen and bar with ability to mark them as ready
- add cashier view that groups orders by table and allows marking them as paid

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452d70fe848321a9195585df74e56a